### PR TITLE
Fix typos

### DIFF
--- a/docs/cogs/gatekeeper.md
+++ b/docs/cogs/gatekeeper.md
@@ -30,7 +30,7 @@ Sets actions to be executed when a member runs `.accept`.
 **Valid actions**:
 - `add role <role:role...>`
 
-  Adds the given `role` to members runnin `.accept`.
+  Adds the given `role` to members running `.accept`.
   If the member already has the role, nothing happens.
   Other errors are logged to the mod log with the event `ERROR`.
 

--- a/docs/cogs/meta.md
+++ b/docs/cogs/meta.md
@@ -121,7 +121,7 @@ features enabled to be able to copy IDs in your client.
 // Display all users within the given range
 .uidrange 192182304263634943 196989358165852161
 
-// Same as above, with inbetween "to" for clarity
+// Same as above, with in between "to" for clarity
 .uidrange 192182304263634943 to 196989358165852161
 
 // Display all users newer than the given snowflake

--- a/lib/bolt/cogs/guide.ex
+++ b/lib/bolt/cogs/guide.ex
@@ -15,7 +15,7 @@ defmodule Bolt.Cogs.Guide do
 
       First off, keep in mind you can always invoke this command using `guide`, and if you want help for commands themselves, use `help <command>`.
       For subcommands (e.g. `infr list`), you can also view detailed help, e.g. `help infr list`.
-      Commands documented here have their prefix ommitted.
+      Commands documented here have their prefix omitted.
 
       To navigate through this guide, use the buttons below.
       """
@@ -116,7 +116,7 @@ defmodule Bolt.Cogs.Guide do
       • `role allow <role>` to make a role self-assignable
       • `role deny <role>` to remove a role from the self-assignable roles
       Use `help role` if you want further information on these commands.
-      These configuration commands will be logged under `CONFIG_UDPATE`.
+      These configuration commands will be logged under `CONFIG_UPDATE`.
 
       Users can then interact with the self-assignable roles using the following:
       • `lsar` to list all self-assignable roles

--- a/lib/bolt/cogs/role/allow.ex
+++ b/lib/bolt/cogs/role/allow.ex
@@ -24,7 +24,7 @@ defmodule Bolt.Cogs.Role.Allow do
 
     **Examples**:
     ```rs
-    // allow self-assginment of the 'Movie Nighter' role
+    // allow self-assignment of the 'Movie Nighter' role
     role allow movie nighter
     ```
     """

--- a/lib/bolt/cogs/role/deny.ex
+++ b/lib/bolt/cogs/role/deny.ex
@@ -24,7 +24,7 @@ defmodule Bolt.Cogs.Role.Deny do
 
     **Examples**:
     ```rs
-    // no longer allow self-assginment of the 'Movie Nighter' role
+    // no longer allow self-assignment of the 'Movie Nighter' role
     role deny movie nighter
     ```
     """

--- a/lib/bolt/paginator.ex
+++ b/lib/bolt/paginator.ex
@@ -54,7 +54,7 @@ defmodule Bolt.Paginator do
       )
 
     # Add the navigator reactions to the embed.
-    # Sleep shortly inbetween to respect ratelimits.
+    # Sleep shortly in between to respect ratelimits.
     {:ok} = Api.create_reaction(original_msg.channel_id, msg.id, "⬅")
     Process.sleep(250)
     {:ok} = Api.create_reaction(original_msg.channel_id, msg.id, "➡")


### PR DESCRIPTION
Found via `codespell -S deps,_build`